### PR TITLE
Fixed compatibility issues with last version of Landing Pages plugin

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -472,3 +472,72 @@ body.blog-post {
     font-size: 1.1em;
   }
 }
+
+.modal {
+  display: none;
+
+  &.active {
+    visibility: visible;
+    z-index: 999;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    position: fixed;
+    display: flex;
+    align-items: center;
+    background-color: rgba(0, 0, 0, 0.4);
+  }
+
+  .modal-container {
+    background: $primary-very-low;
+    padding: 2em;
+    position: relative;
+    margin: auto;
+    box-shadow: shadow("modal");
+    border-radius: 0.3em;
+    width: 30em;
+    max-width: 90%;
+    height: auto;
+    flex-direction: column;
+    align-items: center;
+    box-sizing: border-box;
+
+    .modal-close {
+      cursor: pointer;
+      fill: $primary-low-mid;
+
+      svg {
+        height: 1.2em;
+        width: 1.2em;
+
+        &:hover,
+        &:focus {
+          text-decoration: none;
+          cursor: pointer;
+          fill: $primary-high;
+        }
+      }
+    }
+
+    .modal-header {
+      border-bottom: 1px solid $primary-low;
+      padding-bottom: 0.5em;
+      margin-bottom: 1em;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+
+      .modal-title {
+        margin: 0;
+      }
+    }
+  }
+}
+
+@media only screen and (max-width: 480px) {
+  .modal .modal-container {
+    padding: 1em;
+  }
+}

--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -1,3 +1,4 @@
+<script>
 window.addEventListener('DOMContentLoaded', (event) => {
   var $blog = $('body.blog, body.blog-post');
   var $subscribeModal = $blog.find(".modal.subscribe");
@@ -28,3 +29,4 @@ window.addEventListener('DOMContentLoaded', (event) => {
     }
   });
 });
+</script>


### PR DESCRIPTION
This adds the minimal updates required for the Blog Landing theme to be compatible with the latest version of the Landing Pages plugin:
- Includes the modal related styles that were initially removed from the plugin due compatibility issues with the native Discourse modals.
- Moves the Javascript content into the `head_tag.html` template so it can be loaded as is.